### PR TITLE
Correct namespace error in ACP hooks file

### DIFF
--- a/inc/plugins/itscomplicated/hooks_acp.php
+++ b/inc/plugins/itscomplicated/hooks_acp.php
@@ -95,7 +95,7 @@ function admin_load()
                     'n'
                 );
 
-                $listManager = new \amnesia\ListManager([
+                $listManager = new \itscomplicated\ListManager([
                     'mybb' => $mybb,
                     'baseurl' => $pageUrl . '&amp;action=types',
                     'order_columns' => ['id', 'title'],


### PR DESCRIPTION
This fixes #4.